### PR TITLE
infra: add load balancer configuration to Pulumi

### DIFF
--- a/infra/config/Pulumi.development.yaml
+++ b/infra/config/Pulumi.development.yaml
@@ -1,6 +1,8 @@
 config:
   gcp:project: sde-consent-api
   gcp:region: europe-west2
+  # this domain doesn't exist, using the IP address for development instead
+  sde-consent-api:domain: DOMAIN
   sde-consent-api:db-name: consent-api
   sde-consent-api:db-tier: db-f1-micro
   sde-consent-api:db-version: POSTGRES_14

--- a/infra/config/Pulumi.staging.yaml
+++ b/infra/config/Pulumi.staging.yaml
@@ -1,6 +1,7 @@
 config:
   gcp:project: sde-consent-api
   gcp:region: europe-west2
+  sde-consent-api:domain: gds-single-consent-staging.app
   sde-consent-api:db-name: consent-api
   sde-consent-api:db-tier: db-f1-micro
   sde-consent-api:db-version: POSTGRES_14

--- a/infra/setup_env.py
+++ b/infra/setup_env.py
@@ -13,6 +13,11 @@ from pulumi_gcp import sql
 from pulumi_gcp import storage
 from ruamel.yaml import YAML
 
+# Setup the project before deployments
+# DB instance
+# Github deploy service account with Workload Identity Pools
+# IAM permissions
+
 
 def setup_env(env: str) -> Callable:
     """Wrapper around Pulumi inline program to pass in variables."""


### PR DESCRIPTION
Because the API is public, we want to introduce rate limiting as a preventive measure against DDOS attacks.
In GCP, Rate Limiting is set up via a Cloud Armor policy.

Unfortunately Cloud Armor policies cannot be attached to NEG and serverless services such as Cloud Run services. Typically, they are attached to load balancers.

As such, the trick is to create a load balancer that will sit in front of our cloud run services, and attach the rate limiting policy to it.


This PR creates the Load Balancer. As part of what makes a load balancer, the following resources are created:

- Public IPV4 address
- SSL certifivate
- Backend service (cloudrun)
- NEG region group
- URL routing from HTTPS to the backend service
- URL routing from HTTP to HTTPS via redirect
- Global forwarding rule