### PR TITLE
Stop adding unknown origins to allow-list

### DIFF
--- a/consent_api/__init__.py
+++ b/consent_api/__init__.py
@@ -11,8 +11,17 @@ from consent_api.routers import consent
 from consent_api.routers import dummy_service
 from consent_api.routers import healthcheck
 from consent_api.routers import self_service
+from consent_api.util import register_origins_for_e2e_testing
 
 app = FastAPI()
+
+
+@app.on_event("startup")
+async def startup_event():
+    if config.FLAG_FIXTURES:
+        await register_origins_for_e2e_testing()
+
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],

--- a/consent_api/config/__init__.py
+++ b/consent_api/config/__init__.py
@@ -64,3 +64,6 @@ OTHER_SERVICE_ORIGIN = {
     ),
     Environment.PRODUCTION: defaults.PROD.DEFAULT_OTHER_SERVICE_ORIGIN,
 }.get(Environment(ENV), defaults.DEV.DEFAULT_OTHER_SERVICE_ORIGIN)
+
+
+FLAG_FIXTURES = os.getenv("FLAG_FIXTURES", False) == "True"

--- a/consent_api/util.py
+++ b/consent_api/util.py
@@ -2,6 +2,12 @@
 import base64
 import uuid
 
+from sqlalchemy.dialects.postgresql import insert
+
+from consent_api import config
+from consent_api.database import db_context
+from consent_api.models import Origin
+
 
 def generate_uid():
     """
@@ -10,3 +16,22 @@ def generate_uid():
     This is an encoded UUID4, so should have no personally identifying information.
     """
     return base64.urlsafe_b64encode(uuid.uuid4().bytes).decode("utf8").rstrip("=")
+
+
+async def register_origins_for_e2e_testing():
+    if config.ENV in [
+        config.Environment.DEVELOPMENT.value,
+        config.Environment.TESTING.value,
+    ]:
+        test_origins = [
+            "http://consent-api",
+            "http://dummy-service-1",
+            "http://dummy-service-2",
+        ]
+        async with db_context() as db:
+            for origin in test_origins:
+                async with db.begin():
+                    await db.execute(
+                        insert(Origin).values(origin=origin).on_conflict_do_nothing()
+                    )
+                    print("Registered origin:", origin)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,6 +39,7 @@ services:
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/postgres
       PORT: "80"
       ENV: "${ENV}"
+      FLAG_FIXTURES: "True"
 
   dummy-service-1:
     container_name: dummy-service-1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -119,6 +119,7 @@ services:
       - "$PWD/selenoid/opt:/home/app/logs"
       - "$PWD/Makefile:/home/app/Makefile"
       - "$PWD/consent_api/tests:/home/app/consent_api/tests"
+      - "$PWD/.pytest_cache:/home/app/.pytest_cache"
     entrypoint: ["make", "test-all"]
     # entrypoint: ["tail", "-f", "/dev/null"]
     environment:


### PR DESCRIPTION
* We want to manually add origins to the allow-list when onboarding a service, to keep control over who is using Single Consent API
* Automatic registration allows unknown users to add their domain to the allow-list which may pose a security risk - better to remove the possibility