### PR TITLE
infra: rate limiting policy

### DIFF
--- a/infra/config/Pulumi.dev.yaml
+++ b/infra/config/Pulumi.dev.yaml
@@ -6,5 +6,5 @@ config:
     secure: AAABAHlN6DOXyUDcq0q1r9QgLamMZVsYvz/FA+H6QniKPNY78Mge0AdZ0jBf6SmD
   sde-consent-api:db-tier: db-f1-micro
   sde-consent-api:db-version: POSTGRES_14
-  sde-consent-api:db-deletion-protected: false
+  sde-consent-api:db-deletion-protected: "false"
   sde-consent-api:docker-image: consent-api:v1.7.3

--- a/infra/config/Pulumi.development.yaml
+++ b/infra/config/Pulumi.development.yaml
@@ -6,5 +6,5 @@ config:
   sde-consent-api:db-name: consent-api
   sde-consent-api:db-tier: db-f1-micro
   sde-consent-api:db-version: POSTGRES_14
-  sde-consent-api:db-deletion-protected: false
+  sde-consent-api:db-deletion-protected: "false"
   sde-consent-api:docker-image: consent-api:v1.9.0

--- a/infra/config/Pulumi.staging.yaml
+++ b/infra/config/Pulumi.staging.yaml
@@ -5,5 +5,5 @@ config:
   sde-consent-api:db-name: consent-api
   sde-consent-api:db-tier: db-f1-micro
   sde-consent-api:db-version: POSTGRES_14
-  sde-consent-api:db-deletion-protected: false
+  sde-consent-api:db-deletion-protected: "false"
   sde-consent-api:docker-image: consent-api:v1.7.5

--- a/infra/deploy_service.py
+++ b/infra/deploy_service.py
@@ -191,6 +191,29 @@ def deploy_service(env: str, branch: str | None, tag: str) -> Callable:
             ),
         )
 
+        rate_limiting_rule = compute.SecurityPolicyRuleArgs(
+            priority=1000,
+            action="rate_based_ban",
+            match=compute.SecurityPolicyRuleMatchArgs(
+                versioned_expr="SRC_IPS_V1",
+                config=compute.SecurityPolicyRuleMatchConfigArgs(src_ip_ranges=["*"]),
+            ),
+            rate_limit_options=compute.SecurityPolicyRuleRateLimitOptionsArgs(
+                conform_action="allow",
+                exceed_action="deny(403)",
+                rate_limit_threshold=compute.SecurityPolicyRuleRateLimitOptionsRateLimitThresholdArgs(
+                    count=500, interval_sec=10
+                ),
+                ban_duration_sec=60,
+                enforce_on_key="IP",
+            ),
+        )
+
+        security_policy = compute.SecurityPolicy(
+            resource_name=resource_name(f"{env}--$--security-policy", branch),
+            rules=[rate_limiting_rule],
+        )
+
         backend_service = compute.BackendService(
             resource_name(f"{env}--$--backend-service", name),
             enable_cdn=False,
@@ -199,6 +222,7 @@ def deploy_service(env: str, branch: str | None, tag: str) -> Callable:
                 enable=True, sample_rate=0.5
             ),
             backends=[compute.BackendServiceBackendArgs(group=endpoint_group.id)],
+            security_policy=security_policy.self_link,
         )
 
         # https_map sends all incoming https traffic to the designated backend service

--- a/infra/deploy_service.py
+++ b/infra/deploy_service.py
@@ -119,6 +119,9 @@ def deploy_service(env: str, branch: str | None, tag: str) -> Callable:
         )
 
         cloudrun_service_name = resource_name("$-consent-api", stack)
+        next_color: ProductionColor | None = None
+        latest_color: ProductionColor | None = None
+        latest_rev_name: str | None = None
         if env == "production":
             print("🚀 Deploying new Cloud Run revision to production")
             dot = {
@@ -145,7 +148,7 @@ def deploy_service(env: str, branch: str | None, tag: str) -> Callable:
                     "annotations": {
                         "autoscaling.knative.dev/maxScale": "5",
                         "run.googleapis.com/cloudsql-instances": db_connection,
-                        "production-color": next_color.value,
+                        "production-color": next_color.value if next_color else "none",
                     }
                 },
                 "spec": {
@@ -191,6 +194,15 @@ def deploy_service(env: str, branch: str | None, tag: str) -> Callable:
             ),
         )
 
+        default_rule = compute.SecurityPolicyRuleArgs(
+            priority=2147483647,
+            action="allow",
+            match=compute.SecurityPolicyRuleMatchArgs(
+                versioned_expr="SRC_IPS_V1",
+                config=compute.SecurityPolicyRuleMatchConfigArgs(src_ip_ranges=["*"]),
+            ),
+        )
+
         rate_limiting_rule = compute.SecurityPolicyRuleArgs(
             priority=1000,
             action="rate_based_ban",
@@ -211,7 +223,7 @@ def deploy_service(env: str, branch: str | None, tag: str) -> Callable:
 
         security_policy = compute.SecurityPolicy(
             resource_name=resource_name(f"{env}--$--security-policy", branch),
-            rules=[rate_limiting_rule],
+            rules=[default_rule, rate_limiting_rule],
         )
 
         backend_service = compute.BackendService(


### PR DESCRIPTION
This PR introduces rate limiting on the backend services sitting behind the load balancers.

The policy implements the following behaviour:

- Max 500 requests from a same IP in a 10 seconds window
- If limit is reached, IP is banned for 60 seconds
- Any request from the IP will be returned a `403`


The infra change consists in:

1. Creating security rules
2. Creating a security policy that includes these rules
3. Attaching the security policy to the backend service


The `default_rule` is necessary: GCP requires all security policies to have a "default tule" at the highest priority.


<img width="1244" alt="image" src="https://github.com/alphagov/consent-api/assets/22219650/1126524b-3eab-49fb-857a-b47a9227992a">


<img width="1461" alt="image" src="https://github.com/alphagov/consent-api/assets/22219650/d139a950-de72-4d21-9094-84fbffb73f9f">
