### PR TITLE
Guilhemf/refactor/pass api domain not url

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -10,15 +10,15 @@ See the [Single Consent service README](../README.md).
 
 See the [CommonJS example](https://github.com/alphagov/consent-api/blob/main/client/examples/commonJS-usage/index.js).
 
-Contact data-tools-team@digital.cabinet-office.gov.uk  to get the URL of the API endpoint.
+Contact data-tools-team@digital.cabinet-office.gov.uk to get the URL of the API endpoint.
 
 The library provides the following static methods for finding out which types of
 cookies a user has consented to.
 
-* `hasConsentedToEssential`
-* `hasConsentedToUsage`
-* `hasConsentedToCampaigns`
-* `hasConsentedToSetting`
+- `hasConsentedToEssential`
+- `hasConsentedToUsage`
+- `hasConsentedToCampaigns`
+- `hasConsentedToSetting`
 
 The method `GovSingleConsent.getConsents()` provides the current state of the
 user's consents to all types of cookies.
@@ -27,7 +27,6 @@ user's consents to all types of cookies.
 
 In order to set first-party cookies, the client Javascript must be served with
 your application.
-
 
 We recommend installing the Single Consent client using
 [node package manager (npm)](https://www.npmjs.com/).
@@ -40,8 +39,7 @@ https://www.npmjs.com/package/govuk-single-consent
 
 ### 2. Including the Javascript client
 
-
-The javascript client can be included in different ways.  Choose one below.
+The javascript client can be included in different ways. Choose one below.
 
 #### CommonJS
 
@@ -65,8 +63,8 @@ On the same pages, you need to load your javascript for interacting with the
 
 See the following examples.
 
-* [Cookie banner script](https://github.com/alphagov/consent-api/blob/main/client/example/cookie-banner.js)
-* [Cooke page script](https://github.com/alphagov/consent-api/blob/main/client/example/cookies-page.js)
+- [Cookie banner script](https://github.com/alphagov/consent-api/blob/main/client/example/cookie-banner.js)
+- [Cooke page script](https://github.com/alphagov/consent-api/blob/main/client/example/cookies-page.js)
 
 It is common practice to add Javascript tags just before the end `</body>` tag,
 eg:
@@ -81,7 +79,28 @@ eg:
 </html>
 ```
 
-### 3. Share the user's consent to cookies via the API
+### 3. Passing the base URL to the constructor
+
+You can either pass an environment string, or a custom base URL.
+
+If using an environment string, its value should be either `staging` or `production`.
+
+e.g
+
+```javascript
+const dummyCallback = () => {}
+
+// With an environemnt string to the staging environment
+new GovSingleConsent(dummyCallback, 'staging')
+
+// With an environemnt string to the production environment
+new GovSingleConsent(dummyCallback, 'production')
+
+// With a custom base URL
+new GovSingleConsent(dummyCallback, 'http://some-development-url.com')
+```
+
+### 4. Share the user's consent to cookies via the API
 
 When the user interacts with your cookie banner or cookie settings page to
 consent to or reject cookies you can update the central database by invoking the
@@ -116,14 +135,14 @@ state of a user's consent.
 
 ### Callback
 
-Websites using the Consent API must provide a callback function.  This will be
-invoked each time the consent has been updated.  It will be called with three
+Websites using the Consent API must provide a callback function. This will be
+invoked each time the consent has been updated. It will be called with three
 parameters:
 
-* `consents` An object describing the new consent state.
-* `consentsPreferencesSet` Boolean, the cookie banner must be displayed if this
+- `consents` An object describing the new consent state.
+- `consentsPreferencesSet` Boolean, the cookie banner must be displayed if this
   value is `false`.
-* `error` An object describing any error, otherwise `null`.  If there is an
+- `error` An object describing any error, otherwise `null`. If there is an
   error, then the `consents` object will say that the consents have been
   revoked.
 

--- a/client/examples/commonJS-usage/index.js
+++ b/client/examples/commonJS-usage/index.js
@@ -12,13 +12,13 @@
  * Functions such as "hideCookieBanner" or "sendErrorLog" are conceptual and represent
  * placeholders for your actual implementation.
  *
- * The constant `SINGLE_CONSENT_API_URL` is a dummy URL and should be replaced with the actual
+ * The constant `SINGLE_CONSENT_API_BASE_URL` is a dummy URL and should be replaced with the actual
  * endpoint from which the consent status can be fetched or to which it can be sent.
  */
 
 const { GovSingleConsent } = require('govuk-single-consent')
 
-const SINGLE_CONSENT_API_URL = 'dummy-url.gov.uk'
+const SINGLE_CONSENT_API_BASE_URL = 'dummy-url.gov.uk'
 
 const onConsentsUpdated = (consents, consentsPreferencesSet, error) => {
   // Do something with the consents
@@ -34,8 +34,8 @@ const onConsentsUpdated = (consents, consentsPreferencesSet, error) => {
 }
 
 const singleConsent = new GovSingleConsent(
-  onConsentsUpdated,
-  SINGLE_CONSENT_API_URL
+  SINGLE_CONSENT_API_BASE_URL,
+  onConsentsUpdated
 )
 
 /**

--- a/client/examples/commonJS-usage/index.js
+++ b/client/examples/commonJS-usage/index.js
@@ -34,8 +34,8 @@ const onConsentsUpdated = (consents, consentsPreferencesSet, error) => {
 }
 
 const singleConsent = new GovSingleConsent(
-  SINGLE_CONSENT_API_BASE_URL,
-  onConsentsUpdated
+  onConsentsUpdated,
+  SINGLE_CONSENT_API_BASE_URL
 )
 
 /**

--- a/client/examples/cookie-banner.js
+++ b/client/examples/cookie-banner.js
@@ -53,8 +53,8 @@
     }
 
     this.singleConsent = new GovSingleConsent(
-      onConsentsUpdated.bind(this),
-      window.GovSingleConsentApiURL
+      window.GovSingleConsentApiBaseURL,
+      onConsentsUpdated.bind(this)
     )
   }
 

--- a/client/examples/cookie-banner.js
+++ b/client/examples/cookie-banner.js
@@ -53,8 +53,8 @@
     }
 
     this.singleConsent = new GovSingleConsent(
-      window.GovSingleConsentApiBaseURL,
-      onConsentsUpdated.bind(this)
+      onConsentsUpdated.bind(this),
+      window.GovSingleConsentApiBaseURL
     )
   }
 

--- a/client/examples/cookies-page.js
+++ b/client/examples/cookies-page.js
@@ -28,8 +28,8 @@
     }
 
     this.singleConsent = new GovSingleConsent(
-      window.GovSingleConsentApiBaseURL,
-      onConsentsUpdated.bind(this)
+      onConsentsUpdated.bind(this),
+      window.GovSingleConsentApiBaseURL
     )
   }
 

--- a/client/examples/cookies-page.js
+++ b/client/examples/cookies-page.js
@@ -28,8 +28,8 @@
     }
 
     this.singleConsent = new GovSingleConsent(
-      onConsentsUpdated.bind(this),
-      window.GovSingleConsentApiURL
+      window.GovSingleConsentApiBaseURL,
+      onConsentsUpdated.bind(this)
     )
   }
 

--- a/client/examples/typescript-usage/index.ts
+++ b/client/examples/typescript-usage/index.ts
@@ -32,8 +32,8 @@ const onConsentsUpdated = (consents, consentsPreferencesSet, error) => {
 }
 
 const singleConsent = new GovSingleConsent(
-  SINGLE_CONSENT_API_BASE_URL,
-  onConsentsUpdated
+  onConsentsUpdated,
+  SINGLE_CONSENT_API_BASE_URL
 )
 
 /**

--- a/client/examples/typescript-usage/index.ts
+++ b/client/examples/typescript-usage/index.ts
@@ -10,13 +10,13 @@
  * Functions such as "hideCookieBanner" or "sendErrorLog" are conceptual and represent
  * placeholders for your actual implementation.
  *
- * The constant `SINGLE_CONSENT_API_URL` is a dummy URL and should be replaced with the actual
+ * The constant `SINGLE_CONSENT_API_BASE_URL` is a dummy URL and should be replaced with the actual
  * endpoint from which the consent status can be fetched or to which it can be sent.
  */
 
 import { GovSingleConsent } from 'govuk-single-consent'
 
-const SINGLE_CONSENT_API_URL = 'dummy-url.gov.uk'
+const SINGLE_CONSENT_API_BASE_URL = 'dummy-url.gov.uk'
 
 const onConsentsUpdated = (consents, consentsPreferencesSet, error) => {
   // Do something with the consents
@@ -32,8 +32,8 @@ const onConsentsUpdated = (consents, consentsPreferencesSet, error) => {
 }
 
 const singleConsent = new GovSingleConsent(
-  onConsentsUpdated,
-  SINGLE_CONSENT_API_URL
+  SINGLE_CONSENT_API_BASE_URL,
+  onConsentsUpdated
 )
 
 /**

--- a/client/src/ApiV1.ts
+++ b/client/src/ApiV1.ts
@@ -4,7 +4,7 @@ class ApiV1 {
 
   static readonly Routes = {
     origins: '/origins',
-    consents: '/consents',
+    consents: '/consent',
   }
 
   constructor(baseUrl: string) {

--- a/client/src/ApiV1.ts
+++ b/client/src/ApiV1.ts
@@ -1,0 +1,31 @@
+class ApiV1 {
+  version = 'v1'
+  private baseUrl: string
+
+  static readonly Routes = {
+    origins: '/origins',
+    consents: '/consents',
+  }
+
+  constructor(baseUrl: string) {
+    this.baseUrl = baseUrl
+  }
+
+  private buildUrl(endpoint: string, pathParam?: string): string {
+    let url = `${this.baseUrl}/api/${this.version}${endpoint}`
+    if (pathParam) {
+      url += `/${pathParam}`
+    }
+    return url
+  }
+
+  origins(): string {
+    return this.buildUrl(ApiV1.Routes.origins)
+  }
+
+  consents(id?: string): string {
+    return this.buildUrl(ApiV1.Routes.consents, id || '')
+  }
+}
+
+export default ApiV1

--- a/client/src/GovConsentConfig.ts
+++ b/client/src/GovConsentConfig.ts
@@ -9,9 +9,9 @@ export class GovConsentConfig {
   static COOKIE_LIFETIME = COOKIE_DAYS * 24 * 60 * 60
   uidFromCookie: string
   uidFromUrl: string
-  apiUrl: string
+  baseUrl: string
 
-  constructor(apiUrl: string) {
+  constructor(baseUrl: string) {
     this.uidFromCookie = findByKey(
       GovConsentConfig.UID_KEY,
       document.cookie.split(';')
@@ -21,6 +21,6 @@ export class GovConsentConfig {
       parseUrl(location.href).params
     )
 
-    this.apiUrl = apiUrl
+    this.baseUrl = baseUrl
   }
 }

--- a/client/src/singleconsent.test.ts
+++ b/client/src/singleconsent.test.ts
@@ -73,7 +73,7 @@ describe('Consent Management', () => {
   })
 
   it('should initialise Consent UID to undefined if no initial UID', () => {
-    const consentInstance = new GovSingleConsent(MOCK_API_BASE_URL, jest.fn())
+    const consentInstance = new GovSingleConsent(jest.fn(), MOCK_API_BASE_URL)
     expect(consentInstance.uid).toBeUndefined()
     expect(getCookie(GovConsentConfig.UID_KEY)).toBe(null)
   })
@@ -82,13 +82,14 @@ describe('Consent Management', () => {
     mockCookie()
     const response1 = ['a', 'b']
     const response2 = { data: 'ok' }
-    xhrMock.get(`${MOCK_API_BASE_URL}/v1/origins`, (req, res) =>
+    xhrMock.get(`${MOCK_API_BASE_URL}/api/v1/origins`, (req, res) =>
       res.status(200).body(JSON.stringify(response1))
     )
-    xhrMock.get(`${MOCK_API_BASE_URL}/v1/consents/${MOCK_UID}`, (req, res) =>
-      res.status(200).body(JSON.stringify(response2))
+    xhrMock.get(
+      `${MOCK_API_BASE_URL}/api/v1/consents/${MOCK_UID}`,
+      (req, res) => res.status(200).body(JSON.stringify(response2))
     )
-    const consentInstance = new GovSingleConsent(MOCK_API_BASE_URL, jest.fn())
+    const consentInstance = new GovSingleConsent(jest.fn(), MOCK_API_BASE_URL)
     expect(consentInstance.uid).toBe(MOCK_UID)
     expect(getCookie(GovConsentConfig.UID_KEY)).toBe(MOCK_UID)
   })
@@ -98,15 +99,15 @@ describe('Consent Management', () => {
     const response2 = { data: 'ok' }
     const mockedUrlUid = `test-url-uid`
     const mockedUrl = `${MOCK_URL}?${MOCK_COOKIE_NAME}=${mockedUrlUid}`
-    xhrMock.get(`${MOCK_API_BASE_URL}/v1/origins`, (req, res) =>
+    xhrMock.get(`${MOCK_API_BASE_URL}/api/v1/origins`, (req, res) =>
       res.status(200).body(JSON.stringify(response1))
     )
     xhrMock.get(
-      `${MOCK_API_BASE_URL}/v1/consents/${mockedUrlUid}`,
+      `${MOCK_API_BASE_URL}/api/v1/consents/${mockedUrlUid}`,
       (req, res) => res.status(200).body(JSON.stringify(response2))
     )
     mockWindowURL(mockedUrl)
-    const consentInstance = new GovSingleConsent(MOCK_API_BASE_URL, jest.fn())
+    const consentInstance = new GovSingleConsent(jest.fn(), MOCK_API_BASE_URL)
     expect(consentInstance.uid).toBe(mockedUrlUid)
     expect(getCookie(GovConsentConfig.UID_KEY)).toBe(mockedUrlUid)
   })
@@ -117,15 +118,15 @@ describe('Consent Management', () => {
     const response2 = { data: 'ok' }
     const mockedUrlUid = `test-url-uid`
     const mockedUrl = `${MOCK_URL}?${MOCK_COOKIE_NAME}=${mockedUrlUid}`
-    xhrMock.get(`${MOCK_API_BASE_URL}/v1/origins`, (req, res) =>
+    xhrMock.get(`${MOCK_API_BASE_URL}/api/v1/origins`, (req, res) =>
       res.status(200).body(JSON.stringify(response1))
     )
     xhrMock.get(
-      `${MOCK_API_BASE_URL}/v1/consents/${mockedUrlUid}`,
+      `${MOCK_API_BASE_URL}/api/v1/consents/${mockedUrlUid}`,
       (req, res) => res.status(200).body(JSON.stringify(response2))
     )
     mockWindowURL(mockedUrl)
-    const consentInstance = new GovSingleConsent(MOCK_API_BASE_URL, jest.fn())
+    const consentInstance = new GovSingleConsent(jest.fn(), MOCK_API_BASE_URL)
     expect(consentInstance.uid).toBe(mockedUrlUid)
     expect(getCookie(GovConsentConfig.UID_KEY)).toBe(mockedUrlUid)
   })
@@ -133,15 +134,18 @@ describe('Consent Management', () => {
   it('should timeout the consents if the request takes more than one second', () => {
     mockCookie()
     const response1 = ['a', 'b']
-    xhrMock.get(`${MOCK_API_BASE_URL}/v1/origins`, (req, res) =>
+    xhrMock.get(`${MOCK_API_BASE_URL}/api/v1/origins`, (req, res) =>
       res.status(200).body(JSON.stringify(response1))
     )
-    xhrMock.get(`${MOCK_API_BASE_URL}/v1/consents/${MOCK_UID}`, (req, res) => {
-      return new Promise(() => {})
-    })
+    xhrMock.get(
+      `${MOCK_API_BASE_URL}/api/v1/consents/${MOCK_UID}`,
+      (req, res) => {
+        return new Promise(() => {})
+      }
+    )
     let err
     try {
-      new GovSingleConsent(MOCK_API_BASE_URL, jest.fn())
+      new GovSingleConsent(jest.fn(), MOCK_API_BASE_URL)
       jest.advanceTimersByTime(1001)
     } catch (e) {
       err = e
@@ -152,25 +156,28 @@ describe('Consent Management', () => {
   it('should not timeout the consents if the request takes less than one second', () => {
     mockCookie()
     const response1 = ['a', 'b']
-    xhrMock.get(`${MOCK_API_BASE_URL}/v1/origins`, (req, res) =>
+    xhrMock.get(`${MOCK_API_BASE_URL}/api/v1/origins`, (req, res) =>
       res.status(200).body(JSON.stringify(response1))
     )
-    xhrMock.get(`${MOCK_API_BASE_URL}/v1/consents/${MOCK_UID}`, (req, res) => {
-      return new Promise(() => {})
-    })
-    const consentInstance = new GovSingleConsent(MOCK_API_BASE_URL, jest.fn())
+    xhrMock.get(
+      `${MOCK_API_BASE_URL}/api/v1/consents/${MOCK_UID}`,
+      (req, res) => {
+        return new Promise(() => {})
+      }
+    )
+    const consentInstance = new GovSingleConsent(jest.fn(), MOCK_API_BASE_URL)
     jest.advanceTimersByTime(500)
     expect(consentInstance.uid).toBe(MOCK_UID)
   })
 
   describe('[method]: isConsentPreferencesSet', () => {
     it('should return false if the cookie is not set', () => {
-      new GovSingleConsent(`${MOCK_API_BASE_URL}/v1/consents`, jest.fn())
+      new GovSingleConsent(jest.fn(), `${MOCK_API_BASE_URL}/api/v1/consents`)
       expect(GovSingleConsent.isConsentPreferencesSet()).toBe(false)
     })
 
     it('should return true if the cookie is set', () => {
-      new GovSingleConsent(`${MOCK_API_BASE_URL}/v1/consents`, jest.fn())
+      new GovSingleConsent(jest.fn(), `${MOCK_API_BASE_URL}/api/v1/consents`)
       mockCookie(GovConsentConfig.PREFERENCES_SET_COOKIE_NAME, 'true')
       expect(GovSingleConsent.isConsentPreferencesSet()).toBe(true)
     })

--- a/client/tsconfig.es5.json
+++ b/client/tsconfig.es5.json
@@ -6,5 +6,5 @@
     "skipLibCheck": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "src/**/*.test.ts"]
 }

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -6,5 +6,5 @@
     "skipLibCheck": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "src/**/*.test.ts"]
 }

--- a/consent_api/config/__init__.py
+++ b/consent_api/config/__init__.py
@@ -49,8 +49,6 @@ CONSENT_API_ORIGIN = {
     ),
 }.get(Environment(ENV), defaults.DEV.DEFAULT_CONSENT_API_ORIGIN)
 
-CONSENT_API_URL = f"{CONSENT_API_ORIGIN}/api/v1/consent/"
-
 
 OTHER_SERVICE_ORIGIN = {
     Environment.TESTING: os.getenv(

--- a/consent_api/jinja.py
+++ b/consent_api/jinja.py
@@ -4,7 +4,7 @@
 import jinja2
 from starlette.templating import Jinja2Templates
 
-from consent_api.config import CONSENT_API_URL
+from consent_api.config import CONSENT_API_ORIGIN
 
 templates = Jinja2Templates(
     directory="consent_api/templates",  # required but overridden by loader arg
@@ -18,5 +18,5 @@ templates = Jinja2Templates(
     ),
 )
 templates.env.globals.update(
-    {"CONSENT_API_URL": CONSENT_API_URL},
+    {"CONSENT_API_BASE_URL": CONSENT_API_ORIGIN},
 )

--- a/consent_api/templates/base.html
+++ b/consent_api/templates/base.html
@@ -151,7 +151,7 @@
       </div>
     </footer>
     {% block bodyEnd %}
-      <script>window.GovSingleConsentApiURL="{{ CONSENT_API_URL }}"</script>
+      <script>window.GovSingleConsentApiBaseURL="{{ CONSENT_API_BASE_URL }}"</script>
       <script src="{{ url_for('client', path='dist/singleconsent.iife.js') }}"></script>
       <script src="{{ url_for('client', path='examples/cookie-banner.js') }}"></script>
     {% endblock %}


### PR DESCRIPTION
This PR is mainly the reflection of user feedback as gov.uk developers are onboarding.
It aims at making the JS client more user friendly to use.

- Commit 1: users have to pass only the base url, not the `api/v1` suffix anymore. I've also improved the way API urls are managed in the client, with the `ApiV1` class, removing the need for hardcoding.
- Commit 2: structure the code better and simplify the constructor, something I wanted to do for a long time
- Commit 3: let users pass to the constructor an environment string such as `staging` or `production`, instead of a base url. A custom base URL can also be passed.


All tested and working.