### PR TITLE
fix(client): IE11: req.timeout should be defined after req.open

### DIFF
--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -1,3 +1,5 @@
+const DEFAULT_TIMEOUT = 10000
+
 export function request(url, options, onSuccess, onError) {
   var req = new XMLHttpRequest()
   var isTimeout = false
@@ -30,16 +32,19 @@ export function request(url, options, onSuccess, onError) {
     }
   }
 
+  req.open(options.method || 'GET', url, true)
+
+
   if (options.timeout) {
     req.timeout = options.timeout
+  } else {
+    req.timeout = DEFAULT_TIMEOUT
   }
 
   req.ontimeout = function () {
     isTimeout = true
     onError(new Error('Request to ' + url + ' timed out'))
   }
-
-  req.open(options.method || 'GET', url, true)
 
   var headers = options.headers || {}
   for (var name in headers) {


### PR DESCRIPTION
A bug reported by Ashley Burnett, gov.uk frontend:

_Hi Guilhem, when testing single consent on IE11 I was getting an InvalidStateError  when trying to accept or reject cookies. I researched the error, and it looks like it's because req.timeout is being defined before req.open in the code. So it needs to be defined afterwards._