### PR TITLE
fix: ie11 cross origin 443 ports

### DIFF
--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -1,3 +1,5 @@
+const DEFAULT_TIMEOUT = 10000
+
 export function request(url, options, onSuccess, onError) {
   var req = new XMLHttpRequest()
   var isTimeout = false
@@ -30,16 +32,19 @@ export function request(url, options, onSuccess, onError) {
     }
   }
 
+  req.open(options.method || 'GET', url, true)
+
+
   if (options.timeout) {
     req.timeout = options.timeout
+  } else {
+    req.timeout = DEFAULT_TIMEOUT
   }
 
   req.ontimeout = function () {
     isTimeout = true
     onError(new Error('Request to ' + url + ' timed out'))
   }
-
-  req.open(options.method || 'GET', url, true)
 
   var headers = options.headers || {}
   for (var name in headers) {

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -112,7 +112,7 @@ export function isCrossOrigin(link) {
 
 export function getOriginFromLink(link) {
   var origin = link.protocol.concat('//', link.hostname)
-  if (link.port && link.port !== '80') {
+  if (link.port && link.port !== '80' && link.port !== '443') {
     origin = origin.concat(':', link.port)
   }
   return origin


### PR DESCRIPTION
A bug reported on Internet Explorer 11 from Ashley Burnett (gov.uk frontend):

_ the cross origin code in IE11 is not appending govuk_singleconsent_uid to links. This seems to be because the code is checking for the HTTP Port (port 80) but does not check for the HTTPS port (port 443). Therefore it can be fixed with something like this:
 function getOriginFromLink(link) {

        var origin = link.protocol.concat('//', link.hostname);
        if (link.port && link.port !== '80' && link.port !== '443') {
            origin = origin.concat(':', link.port);
        }
        if(link.href.indexOf('staging') != -1) {
            console.log("Getting origin from link")
            console.log(origin)
        }
        return origin;
    }_