### PR TITLE
Add opt in field to User table

### DIFF
--- a/db/migrate/20260519085814_add_opt_in_to_users.rb
+++ b/db/migrate/20260519085814_add_opt_in_to_users.rb
@@ -1,0 +1,5 @@
+class AddOptInToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :opt_in, :boolean, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_18_102911) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_19_085814) do
   create_table "users", force: :cascade do |t|
     t.string "apprenticeId"
     t.string "colCampaignId"
     t.datetime "created_at", null: false
     t.string "govukId"
+    t.boolean "opt_in", null: false
     t.datetime "updated_at", null: false
   end
 end


### PR DESCRIPTION
This will be used when a new user comes to a site and clicks on or closes the cookie banner. It will record their cookie preference for later use across all sites that are included in cross domain tracking